### PR TITLE
fix: image opening does not work on linux

### DIFF
--- a/lua/diagram/hover.lua
+++ b/lua/diagram/hover.lua
@@ -175,7 +175,7 @@ M.show_diagram_hover = function(diagram, integrations, renderer_options)
     end, { buffer = buf, desc = "Close diagram tab" })
     
     vim.keymap.set("n", "o", function()
-      vim.fn.system("open " .. vim.fn.shellescape(renderer_result.file_path))
+      vim.ui.open(renderer_result.file_path)
     end, { buffer = buf, desc = "Open image with system viewer" })
   end
   


### PR DESCRIPTION
Signature
```
function M.open(path: string, opt?: { cmd: string[] })
  -> vim.SystemObj|nil
  2. string|nil

 Opens `path` with the system default handler (macOS `open`, Windows `explorer.exe`, Linux
 `xdg-open`, …), or returns (but does not show) an error message on failure.
```

Notice that with `vim.fn.system("open "` we are not handling the linux-way to open things with standard binaries, the standard way is with `xdg-open`. I am using `vim.ui.open` because it handle it for us.